### PR TITLE
Use product code for detail endpoints

### DIFF
--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -5,7 +5,7 @@ import ProductSearch from "@/components/product-search";
 import type { Product } from "@shared/schema";
 
 interface HeaderProps {
-  onProductSelect: (productId: number) => void;
+  onProductSelect: (productCode: string) => void;
 }
 
 export default function Header({ onProductSelect }: HeaderProps) {
@@ -21,7 +21,7 @@ export default function Header({ onProductSelect }: HeaderProps) {
           </div>
           <div className="flex items-center space-x-4">
             <div className="relative flex-1 max-w-lg">
-              <ProductSearch onProductSelect={onProductSelect} />
+              <ProductSearch onSelectProduct={onProductSelect} />
             </div>
             <button className="p-2 text-gray-400 hover:text-gray-600">
               <Bell className="text-lg" />

--- a/client/src/components/product-details.tsx
+++ b/client/src/components/product-details.tsx
@@ -15,33 +15,33 @@ import { apiRequest } from "@/lib/queryClient";
 import { queryClient } from "@/lib/queryClient";
 
 interface ProductDetailsProps {
-  productId: number | null;
+  productCode: string | null;
 }
 
-export default function ProductDetails({ productId }: ProductDetailsProps) {
+export default function ProductDetails({ productCode }: ProductDetailsProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [showAllAttributes, setShowAllAttributes] = useState(false);
   const [formData, setFormData] = useState<Product | null>(null);
   const { toast } = useToast();
 
   const { data: product, isLoading } = useQuery<Product>({
-    queryKey: ['/products', productId],
-    enabled: !!productId,
+    queryKey: [`/products/${productCode}`],
+    enabled: !!productCode,
   });
 
   const { data: analytics } = useQuery<ProductAnalytics[]>({
-    queryKey: ['/analytics/products', productId],
-    enabled: !!productId,
+    queryKey: [`/analytics/products/${productCode}`],
+    enabled: !!productCode,
   });
 
   const updateMutation = useMutation({
     mutationFn: async (data: Partial<Product>) => {
-      if (!productId) throw new Error('No product ID');
-      return apiRequest('PUT', `/products/${productId}`, data);
+      if (!productCode) throw new Error('No product code');
+      return apiRequest('PUT', `/products/${productCode}`, data);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/products'] });
-      queryClient.invalidateQueries({ queryKey: ['/products', productId] });
+      queryClient.invalidateQueries({ queryKey: [`/products/${productCode}`] });
       setIsEditing(false);
       toast({
         title: "Success",
@@ -69,7 +69,7 @@ export default function ProductDetails({ productId }: ProductDetailsProps) {
     }
   }, [isEditing]);
 
-  if (!productId) {
+  if (!productCode) {
     return (
       <div className="p-6 text-center">
         <p className="text-gray-500">Select a product from the search to view details</p>

--- a/client/src/components/product-search.tsx
+++ b/client/src/components/product-search.tsx
@@ -6,7 +6,7 @@ import { Product } from "@shared/schema";
 import { API_BASE_URL } from "@/config";
 
 interface ProductSearchProps {
-  onSelectProduct: (productId: number) => void;
+  onSelectProduct: (productCode: string) => void;
 }
 
 export default function ProductSearch({ onSelectProduct }: ProductSearchProps) {
@@ -31,7 +31,7 @@ export default function ProductSearch({ onSelectProduct }: ProductSearchProps) {
   }, [query, searchResults]);
 
   const handleSelectProduct = (product: Product) => {
-    onSelectProduct(product.id);
+    onSelectProduct(product.product_code);
     setQuery(product.product_name);
     setShowResults(false);
   };

--- a/client/src/pages/product-management.tsx
+++ b/client/src/pages/product-management.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/dialog";
 
 export default function ProductManagement() {
-  const [selectedProductId, setSelectedProductId] = useState<number | null>(null);
+  const [selectedProductCode, setSelectedProductCode] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
   const [bulkOpen, setBulkOpen] = useState(false);
 
@@ -74,7 +74,7 @@ export default function ProductManagement() {
                 <TabsContent value="products" className="mt-0 h-full">
                   <div className="flex flex-col items-center p-6">
                     <div className="w-full max-w-lg mx-auto">
-                      <ProductSearch onSelectProduct={setSelectedProductId} />
+                      <ProductSearch onSelectProduct={setSelectedProductCode} />
                     </div>
                     <div className="mt-4 flex gap-4">
                       <Dialog open={addOpen} onOpenChange={setAddOpen}>
@@ -95,7 +95,7 @@ export default function ProductManagement() {
                       </Dialog>
                     </div>
                     <div className="mt-6 w-full">
-                      <ProductDetails productId={selectedProductId} />
+                      <ProductDetails productCode={selectedProductCode} />
                     </div>
                   </div>
                 </TabsContent>


### PR DESCRIPTION
## Summary
- update ProductSearch to return product code
- store selected product code in state
- retrieve product details via `/products/{product_code}`
- update Header to use new prop name

## Testing
- `npm run check` *(fails: add-product.tsx type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859920f0c38832886964aec7aa9c1e2