### PR TITLE
Fix save functionality for deals

### DIFF
--- a/client/src/components/deal-list.tsx
+++ b/client/src/components/deal-list.tsx
@@ -1,6 +1,11 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Edit } from "lucide-react";
+import AddDeal from "@/components/add-deal";
 import { Deal } from "@shared/schema";
 
 interface DealListProps {
@@ -8,6 +13,8 @@ interface DealListProps {
 }
 
 export default function DealList({ productId }: DealListProps) {
+  const [editingDeal, setEditingDeal] = useState<Deal | null>(null);
+
   const { data: deals = [], isLoading } = useQuery<Deal[]>({
     queryKey: ['/deals', productId],
     enabled: !!productId,
@@ -41,27 +48,44 @@ export default function DealList({ productId }: DealListProps) {
         </CardHeader>
         <CardContent>
           <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Type</TableHead>
-                <TableHead>Amount</TableHead>
-                <TableHead>Start</TableHead>
-                <TableHead>End</TableHead>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Type</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead>Start</TableHead>
+              <TableHead>End</TableHead>
+              <TableHead>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {deals.map((deal) => (
+              <TableRow key={deal.deal_id}>
+                <TableCell>{deal.deal_type}</TableCell>
+                <TableCell>{deal.amount}</TableCell>
+                <TableCell>{deal.start_date}</TableCell>
+                <TableCell>{deal.end_date}</TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setEditingDeal(deal)}
+                  >
+                    <Edit className="h-4 w-4" />
+                  </Button>
+                </TableCell>
               </TableRow>
-            </TableHeader>
-            <TableBody>
-              {deals.map((deal) => (
-                <TableRow key={deal.deal_id}>
-                  <TableCell>{deal.deal_type}</TableCell>
-                  <TableCell>{deal.amount}</TableCell>
-                  <TableCell>{deal.start_date}</TableCell>
-                  <TableCell>{deal.end_date}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </CardContent>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
       </Card>
+      <Dialog open={!!editingDeal} onOpenChange={(open) => !open && setEditingDeal(null)}>
+        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+          {editingDeal && (
+            <AddDeal deal={editingDeal} onClose={() => setEditingDeal(null)} />
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/components/product-details.tsx
+++ b/client/src/components/product-details.tsx
@@ -181,6 +181,12 @@ export default function ProductDetails({ productCode }: ProductDetailsProps) {
                     <Edit className="h-4 w-4 mr-2" />
                     {isEditing ? 'Cancel' : 'Edit Product'}
                   </Button>
+                  {isEditing && (
+                    <Button type="submit" size="sm" disabled={updateMutation.isPending}>
+                      <Save className="h-4 w-4 mr-2" />
+                      {updateMutation.isPending ? 'Saving...' : 'Save'}
+                    </Button>
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- support editing deals by passing existing deal to AddDeal
- send PUT request to `/deals/{deal_uuid}` when editing and show Save button
- add Edit buttons in DealList with dialog for editing

## Testing
- `npm run check` *(fails: TS2322 type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b00aa95608328a879511a53e5371d