### PR TITLE
Add user dropdown with logout

### DIFF
--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -1,8 +1,6 @@
-import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { Store, Search, Bell } from "lucide-react";
 import ProductSearch from "@/components/product-search";
-import type { Product } from "@shared/schema";
+import UserMenu from "@/components/user-menu";
 
 interface HeaderProps {
   onProductSelect: (productCode: string) => void;
@@ -26,14 +24,7 @@ export default function Header({ onProductSelect }: HeaderProps) {
             <button className="p-2 text-gray-400 hover:text-gray-600">
               <Bell className="text-lg" />
             </button>
-            <div className="flex items-center space-x-2">
-              <img
-                src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-4.0.3&auto=format&fit=crop&w=32&h=32"
-                alt="User avatar"
-                className="w-8 h-8 rounded-full"
-              />
-              <span className="text-sm text-gray-700">John Manager</span>
-            </div>
+            <UserMenu />
           </div>
         </div>
       </div>

--- a/client/src/components/user-menu.tsx
+++ b/client/src/components/user-menu.tsx
@@ -1,0 +1,39 @@
+import { useKeycloak } from "@react-keycloak/web";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+export default function UserMenu() {
+  const { keycloak } = useKeycloak();
+  const name =
+    (keycloak.tokenParsed as any)?.name ||
+    (keycloak.tokenParsed as any)?.preferred_username ||
+    "User";
+  const initials = name
+    .split(" ")
+    .map((n: string) => n[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button className="flex items-center space-x-2 focus:outline-none">
+          <Avatar className="w-8 h-8">
+            <AvatarImage src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-4.0.3&auto=format&fit=crop&w=32&h=32" />
+            <AvatarFallback>{initials}</AvatarFallback>
+          </Avatar>
+          <span className="text-sm text-gray-700">{name}</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={() => keycloak.logout()}>Logout</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/client/src/pages/product-management.tsx
+++ b/client/src/pages/product-management.tsx
@@ -11,7 +11,7 @@ import DealList from "@/components/deal-list";
 import Analytics from "@/components/analytics";
 import { Store, Bell } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import UserMenu from "@/components/user-menu";
 import {
   Dialog,
   DialogContent,
@@ -40,13 +40,7 @@ export default function ProductManagement() {
               <Button variant="ghost" size="icon">
                 <Bell className="h-5 w-5 text-gray-400" />
               </Button>
-              <div className="flex items-center space-x-2">
-                <Avatar className="w-8 h-8">
-                  <AvatarImage src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-4.0.3&auto=format&fit=crop&w=32&h=32" />
-                  <AvatarFallback>JM</AvatarFallback>
-                </Avatar>
-                <span className="text-sm text-gray-700">John Manager</span>
-              </div>
+              <UserMenu />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add `UserMenu` component implementing dropdown with avatar, name and logout
- use `UserMenu` in layout header and product-management page

## Testing
- `npm run check` *(fails: TS2322 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_685cbf966bec83288be5fe365f8e1594