### PR TITLE
Add search select for product in AddDeal

### DIFF
--- a/client/src/components/add-deal.tsx
+++ b/client/src/components/add-deal.tsx
@@ -5,6 +5,7 @@ import { useMutation } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import ProductSearchWithId from "@/components/product-search-with-id";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
@@ -119,10 +120,16 @@ export default function AddDeal({ deal, onClose }: AddDealProps) {
                   name="product_id"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Product ID</FormLabel>
-                      <FormControl>
-                        <Input type="number" {...field} />
-                      </FormControl>
+                      <FormLabel>Product</FormLabel>
+                      {isEditing ? (
+                        <FormControl>
+                          <Input type="number" {...field} disabled />
+                        </FormControl>
+                      ) : (
+                        <ProductSearchWithId
+                          onSelectProduct={(product) => field.onChange(product.id)}
+                        />
+                      )}
                       <FormMessage />
                     </FormItem>
                   )}

--- a/client/src/components/product-search-with-id.tsx
+++ b/client/src/components/product-search-with-id.tsx
@@ -1,0 +1,72 @@
+import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Input } from "@/components/ui/input";
+import { Search } from "lucide-react";
+import { Product } from "@shared/schema";
+import { API_BASE_URL } from "@/config";
+import { authHeaders } from "@/lib/auth";
+
+interface ProductSearchWithIdProps {
+  onSelectProduct: (product: Product) => void;
+}
+
+export default function ProductSearchWithId({ onSelectProduct }: ProductSearchWithIdProps) {
+  const [query, setQuery] = useState("");
+  const [showResults, setShowResults] = useState(false);
+
+  const { data: searchResults = [] } = useQuery<Product[]>({
+    queryKey: ["/products/search", query],
+    queryFn: async () => {
+      if (query.length < 2) return [];
+      const response = await fetch(
+        `${API_BASE_URL}/products/search?q=${encodeURIComponent(query)}`,
+        { headers: authHeaders() },
+      );
+      if (!response.ok) throw new Error("Search failed");
+      return response.json();
+    },
+    enabled: query.length >= 2,
+  });
+
+  useEffect(() => {
+    setShowResults(query.length >= 2 && searchResults.length > 0);
+  }, [query, searchResults]);
+
+  const handleSelectProduct = (product: Product) => {
+    onSelectProduct(product);
+    setQuery(product.product_name);
+    setShowResults(false);
+  };
+
+  return (
+    <div className="relative">
+      <div className="relative">
+        <Input
+          type="text"
+          placeholder="Search products by name, code, or brand..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => query.length >= 2 && setShowResults(true)}
+          className="w-full pl-10 pr-4 py-2"
+        />
+        <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+      </div>
+
+      {showResults && (
+        <div className="absolute top-full left-0 right-0 bg-white border border-gray-200 rounded-lg shadow-lg mt-1 max-h-60 overflow-y-auto z-50">
+          {searchResults.map((product) => (
+            <div
+              key={product.id}
+              className="p-3 hover:bg-gray-50 cursor-pointer border-b border-gray-100 last:border-b-0"
+              onClick={() => handleSelectProduct(product)}
+            >
+              <div className="font-medium text-gray-900">{product.product_name}</div>
+              <div className="text-sm text-gray-500">{product.product_code}</div>
+              <div className="text-sm text-gray-600">{product.brand_name}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- enable selecting a product by search instead of typing numeric ID when creating deals
- create `ProductSearchWithId` component returning full product info

## Testing
- `npm run check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0acf9aac8328bc379cb25dea38b4