### PR TITLE
Add CTC hierarchy page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import ProductManagement from "@/pages/product-management";
 import DistributorsPage from "@/pages/distributors";
+import CTCHierarchyPage from "@/pages/ctc-hierarchy";
 import NotFound from "@/pages/not-found";
 import { keycloak, keycloakConfig } from "./keycloak";
 
@@ -16,6 +17,7 @@ function Router() {
       <Route path="/" component={ProductManagement} />
       <Route path="/products" component={ProductManagement} />
       <Route path="/distributors" component={DistributorsPage} />
+      <Route path="/ctc-hierarchy" component={CTCHierarchyPage} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/ctc-attributes-dialog.tsx
+++ b/client/src/components/ctc-attributes-dialog.tsx
@@ -1,0 +1,253 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+
+const attrSchema = z.object({
+  code: z.string().min(1, "Required"),
+  title: z.string().min(1, "Required"),
+  description: z.string().min(1, "Required"),
+  image_url: z.string().optional().or(z.literal("")),
+});
+
+export type AttributeForm = z.infer<typeof attrSchema>;
+
+interface CategoryAttribute {
+  id: number;
+  code: string;
+  title: string;
+  description: string;
+  image_url?: string | null;
+}
+
+interface CTCAttributesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  categoryId: number;
+  name: string;
+}
+
+export default function CTCAttributesDialog({
+  open,
+  onOpenChange,
+  categoryId,
+  name,
+}: CTCAttributesDialogProps) {
+  const { data: attributes = [], isLoading } = useQuery<CategoryAttribute[]>({
+    queryKey: ["/ctc/features-benefits/category/", categoryId, "/attributes"],
+    enabled: open,
+  });
+
+  const form = useForm<AttributeForm>({
+    resolver: zodResolver(attrSchema),
+    defaultValues: { code: "", title: "", description: "", image_url: "" },
+  });
+
+  const [editing, setEditing] = React.useState<CategoryAttribute | null>(null);
+
+  React.useEffect(() => {
+    if (editing) {
+      form.reset({
+        code: editing.code || "",
+        title: editing.title || "",
+        description: editing.description || "",
+        image_url: editing.image_url || "",
+      });
+    } else {
+      form.reset({ code: "", title: "", description: "", image_url: "" });
+    }
+  }, [editing, form]);
+
+  const mutation = useMutation({
+    mutationFn: async (data: AttributeForm) => {
+      if (editing) {
+        return apiRequest(
+          "PUT",
+          `/ctc/features-benefits/category/attribute/${editing.id}`,
+          {
+            code: data.code,
+            title: data.title,
+            description: data.description,
+            image_url: data.image_url,
+          },
+        );
+      }
+      return apiRequest("POST", `/ctc/features-benefits/category/attribute`, {
+        category_id: categoryId,
+        code: data.code,
+        title: data.title,
+        description: data.description,
+        image_url: data.image_url,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["/ctc/features-benefits/category/", categoryId, "/attributes"],
+      });
+      setEditing(null);
+      form.reset();
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) =>
+      apiRequest("DELETE", `/ctc/features-benefits/category/attribute/${id}`),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ["/ctc/features-benefits/category/", categoryId, "/attributes"],
+      }),
+  });
+
+  const onSubmit = (data: AttributeForm) => {
+    mutation.mutate(data);
+  };
+
+  const close = (o: boolean) => {
+    if (!o) {
+      setEditing(null);
+      form.reset();
+    }
+    onOpenChange(o);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{name} Attributes</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6">
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="code"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Code</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Title</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem className="col-span-2">
+                      <FormLabel>Description</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="image_url"
+                  render={({ field }) => (
+                    <FormItem className="col-span-2">
+                      <FormLabel>Image URL</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="flex justify-end space-x-2">
+                {editing && (
+                  <Button type="button" variant="secondary" onClick={() => setEditing(null)}>
+                    Cancel
+                  </Button>
+                )}
+                <Button type="submit" disabled={mutation.isPending}>
+                  {editing ? "Update" : "Add"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+          <div>
+            {isLoading ? (
+              <div>Loading...</div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Code</TableHead>
+                    <TableHead>Title</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead>Image URL</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {attributes.map((attr) => (
+                    <TableRow key={attr.id}>
+                      <TableCell>{attr.code}</TableCell>
+                      <TableCell>{attr.title}</TableCell>
+                      <TableCell>{attr.description}</TableCell>
+                      <TableCell>{attr.image_url}</TableCell>
+                      <TableCell className="space-x-2">
+                        <Button variant="ghost" size="sm" onClick={() => setEditing(attr)}>
+                          Edit
+                        </Button>
+                        <Button variant="ghost" size="sm" onClick={() => deleteMutation.mutate(attr.id)}>
+                          Delete
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/ctc-attributes-dialog.tsx
+++ b/client/src/components/ctc-attributes-dialog.tsx
@@ -60,7 +60,7 @@ export default function CTCAttributesDialog({
   name,
 }: CTCAttributesDialogProps) {
   const { data: attributes = [], isLoading } = useQuery<CategoryAttribute[]>({
-    queryKey: ["/ctc/features-benefits/category/", categoryId, "/attributes"],
+    queryKey: ["/ctc/categories/", categoryId, "/attributes"],
     enabled: open,
   });
 
@@ -89,16 +89,17 @@ export default function CTCAttributesDialog({
       if (editing) {
         return apiRequest(
           "PUT",
-          `/ctc/features-benefits/category/attribute/${editing.id}`,
+          `/ctc/attributes/${editing.id}`,
           {
             code: data.code,
             title: data.title,
             description: data.description,
             image_url: data.image_url,
+            category_id: categoryId,
           },
         );
       }
-      return apiRequest("POST", `/ctc/features-benefits/category/attribute`, {
+      return apiRequest("POST", `/ctc/attributes`, {
         category_id: categoryId,
         code: data.code,
         title: data.title,
@@ -108,7 +109,7 @@ export default function CTCAttributesDialog({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["/ctc/features-benefits/category/", categoryId, "/attributes"],
+        queryKey: ["/ctc/categories/", categoryId, "/attributes"],
       });
       setEditing(null);
       form.reset();
@@ -117,10 +118,10 @@ export default function CTCAttributesDialog({
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) =>
-      apiRequest("DELETE", `/ctc/features-benefits/category/attribute/${id}`),
+      apiRequest("DELETE", `/ctc/attributes/${id}`),
     onSuccess: () =>
       queryClient.invalidateQueries({
-        queryKey: ["/ctc/features-benefits/category/", categoryId, "/attributes"],
+        queryKey: ["/ctc/categories/", categoryId, "/attributes"],
       }),
   });
 

--- a/client/src/components/ctc-features-dialog.tsx
+++ b/client/src/components/ctc-features-dialog.tsx
@@ -1,0 +1,272 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+
+const featureSchema = z.object({
+  code: z.string().min(1, "Required"),
+  title: z.string().min(1, "Required"),
+  description: z.string().min(1, "Required"),
+  image_url: z.string().optional().or(z.literal("")),
+});
+
+export type FeatureForm = z.infer<typeof featureSchema>;
+
+interface CTCFeature {
+  id: number;
+  external_code: string;
+  feature_name: string;
+  feature_description: string;
+  image_url?: string | null;
+}
+
+interface CTCFeaturesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  level: "class" | "type" | "category";
+  sourceId: number;
+  name: string;
+}
+
+export default function CTCFeaturesDialog({
+  open,
+  onOpenChange,
+  level,
+  sourceId,
+  name,
+}: CTCFeaturesDialogProps) {
+  const { data: features = [], isLoading } = useQuery<CTCFeature[]>({
+    queryKey: ["/ctc/features-benefits/", level, "/", sourceId],
+    enabled: open,
+  });
+
+  const form = useForm<FeatureForm>({
+    resolver: zodResolver(featureSchema),
+    defaultValues: { code: "", title: "", description: "", image_url: "" },
+  });
+
+  const [editing, setEditing] = React.useState<CTCFeature | null>(null);
+
+  React.useEffect(() => {
+    if (editing) {
+      form.reset({
+        code: editing.external_code || "",
+        title: editing.feature_name || "",
+        description: editing.feature_description || "",
+        image_url: editing.image_url || "",
+      });
+    } else {
+      form.reset({ code: "", title: "", description: "", image_url: "" });
+    }
+  }, [editing, form]);
+
+  const mutation = useMutation({
+    mutationFn: async (data: FeatureForm) => {
+      if (editing) {
+        return apiRequest(
+          "PUT",
+          `/ctc/features-benefits/${level}/${editing.id}`,
+          {
+            external_code: data.code,
+            feature_name: data.title,
+            feature_description: data.description,
+            image_url: data.image_url,
+          },
+        );
+      }
+      return apiRequest(`POST`, `/ctc/features-benefits/${level}`, {
+        external_code: data.code,
+        feature_name: data.title,
+        feature_description: data.description,
+        image_url: data.image_url,
+        source_level: level,
+        source_level_id: sourceId,
+        [`${level}_id`]: sourceId,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["/ctc/features-benefits/", level, "/", sourceId],
+      });
+      setEditing(null);
+      form.reset();
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) =>
+      apiRequest("DELETE", `/ctc/features-benefits/${level}/${id}`),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ["/ctc/features-benefits/", level, "/", sourceId],
+      }),
+  });
+
+  const onSubmit = (data: FeatureForm) => {
+    mutation.mutate(data);
+  };
+
+  const close = (o: boolean) => {
+    if (!o) {
+      setEditing(null);
+      form.reset();
+    }
+    onOpenChange(o);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{name} Features &amp; Benefits</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6">
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(onSubmit)}
+              className="space-y-4"
+            >
+              <div className="grid grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="code"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Code</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Title</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem className="col-span-2">
+                      <FormLabel>Description</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="image_url"
+                  render={({ field }) => (
+                    <FormItem className="col-span-2">
+                      <FormLabel>Image URL</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="flex justify-end space-x-2">
+                {editing && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => setEditing(null)}
+                  >
+                    Cancel
+                  </Button>
+                )}
+                <Button type="submit" disabled={mutation.isPending}>
+                  {editing ? "Update" : "Add"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+          <div>
+            {isLoading ? (
+              <div>Loading...</div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Code</TableHead>
+                    <TableHead>Title</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead>Image URL</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {features.map((fb) => (
+                    <TableRow key={fb.id}>
+                      <TableCell>{fb.external_code}</TableCell>
+                      <TableCell>{fb.feature_name}</TableCell>
+                      <TableCell>{fb.feature_description}</TableCell>
+                      <TableCell>{fb.image_url}</TableCell>
+                      <TableCell className="space-x-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setEditing(fb)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => deleteMutation.mutate(fb.id)}
+                        >
+                          Delete
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 const navigation = [
   { name: 'Product Management', href: '/products', icon: Box },
   { name: 'Distributors & Brands', href: '/distributors', icon: Warehouse },
+  { name: 'CTC Hierarchy', href: '/ctc-hierarchy', icon: Box },
   { name: 'Sales Analytics', href: '#', icon: ChartLine },
   { name: 'Inventory', href: '#', icon: Warehouse },
   { name: 'Customers', href: '#', icon: Users },

--- a/client/src/components/ui/tree-view.tsx
+++ b/client/src/components/ui/tree-view.tsx
@@ -1,0 +1,490 @@
+'use client'
+
+import React from 'react'
+import * as AccordionPrimitive from '@radix-ui/react-accordion'
+import { ChevronRight } from 'lucide-react'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const treeVariants = cva(
+    'group hover:before:opacity-100 before:absolute before:rounded-lg before:left-0 px-2 before:w-full before:opacity-0 before:bg-accent/70 before:h-[2rem] before:-z-10'
+)
+
+const selectedTreeVariants = cva(
+    'before:opacity-100 before:bg-accent/70 text-accent-foreground'
+)
+
+const dragOverVariants = cva(
+    'before:opacity-100 before:bg-primary/20 text-primary-foreground'
+)
+
+interface TreeDataItem {
+    id: string
+    name: string
+    icon?: any
+    selectedIcon?: any
+    openIcon?: any
+    children?: TreeDataItem[]
+    actions?: React.ReactNode
+    onClick?: () => void
+    draggable?: boolean
+    droppable?: boolean
+    disabled?: boolean
+}
+
+type TreeProps = React.HTMLAttributes<HTMLDivElement> & {
+    data: TreeDataItem[] | TreeDataItem
+    initialSelectedItemId?: string
+    onSelectChange?: (item: TreeDataItem | undefined) => void
+    expandAll?: boolean
+    defaultNodeIcon?: any
+    defaultLeafIcon?: any
+    onDocumentDrag?: (sourceItem: TreeDataItem, targetItem: TreeDataItem) => void
+}
+
+const TreeView = React.forwardRef<HTMLDivElement, TreeProps>(
+    (
+        {
+            data,
+            initialSelectedItemId,
+            onSelectChange,
+            expandAll,
+            defaultLeafIcon,
+            defaultNodeIcon,
+            className,
+            onDocumentDrag,
+            ...props
+        },
+        ref
+    ) => {
+        const [selectedItemId, setSelectedItemId] = React.useState<
+            string | undefined
+        >(initialSelectedItemId)
+        
+        const [draggedItem, setDraggedItem] = React.useState<TreeDataItem | null>(null)
+
+        const handleSelectChange = React.useCallback(
+            (item: TreeDataItem | undefined) => {
+                setSelectedItemId(item?.id)
+                if (onSelectChange) {
+                    onSelectChange(item)
+                }
+            },
+            [onSelectChange]
+        )
+
+        const handleDragStart = React.useCallback((item: TreeDataItem) => {
+            setDraggedItem(item)
+        }, [])
+
+        const handleDrop = React.useCallback((targetItem: TreeDataItem) => {
+            if (draggedItem && onDocumentDrag && draggedItem.id !== targetItem.id) {
+                onDocumentDrag(draggedItem, targetItem)
+            }
+            setDraggedItem(null)
+        }, [draggedItem, onDocumentDrag])
+
+        const expandedItemIds = React.useMemo(() => {
+            if (!initialSelectedItemId) {
+                return [] as string[]
+            }
+
+            const ids: string[] = []
+
+            function walkTreeItems(
+                items: TreeDataItem[] | TreeDataItem,
+                targetId: string
+            ) {
+                if (items instanceof Array) {
+                    for (let i = 0; i < items.length; i++) {
+                        ids.push(items[i]!.id)
+                        if (walkTreeItems(items[i]!, targetId) && !expandAll) {
+                            return true
+                        }
+                        if (!expandAll) ids.pop()
+                    }
+                } else if (!expandAll && items.id === targetId) {
+                    return true
+                } else if (items.children) {
+                    return walkTreeItems(items.children, targetId)
+                }
+            }
+
+            walkTreeItems(data, initialSelectedItemId)
+            return ids
+        }, [data, expandAll, initialSelectedItemId])
+
+        return (
+            <div className={cn('overflow-hidden relative p-2', className)}>
+                <TreeItem
+                    data={data}
+                    ref={ref}
+                    selectedItemId={selectedItemId}
+                    handleSelectChange={handleSelectChange}
+                    expandedItemIds={expandedItemIds}
+                    defaultLeafIcon={defaultLeafIcon}
+                    defaultNodeIcon={defaultNodeIcon}
+                    handleDragStart={handleDragStart}
+                    handleDrop={handleDrop}
+                    draggedItem={draggedItem}
+                    {...props}
+                />
+                <div
+                    className='w-full h-[48px]'
+                    onDrop={(e) => { handleDrop({id: '', name: 'parent_div'})}}>
+
+                </div>
+            </div>
+        )
+    }
+)
+TreeView.displayName = 'TreeView'
+
+type TreeItemProps = TreeProps & {
+    selectedItemId?: string
+    handleSelectChange: (item: TreeDataItem | undefined) => void
+    expandedItemIds: string[]
+    defaultNodeIcon?: any
+    defaultLeafIcon?: any
+    handleDragStart?: (item: TreeDataItem) => void
+    handleDrop?: (item: TreeDataItem) => void
+    draggedItem: TreeDataItem | null
+}
+
+const TreeItem = React.forwardRef<HTMLDivElement, TreeItemProps>(
+    (
+        {
+            className,
+            data,
+            selectedItemId,
+            handleSelectChange,
+            expandedItemIds,
+            defaultNodeIcon,
+            defaultLeafIcon,
+            handleDragStart,
+            handleDrop,
+            draggedItem,
+            ...props
+        },
+        ref
+    ) => {
+        if (!(data instanceof Array)) {
+            data = [data]
+        }
+        return (
+            <div ref={ref} role="tree" className={className} {...props}>
+                <ul>
+                    {data.map((item) => (
+                        <li key={item.id}>
+                            {item.children ? (
+                                <TreeNode
+                                    item={item}
+                                    selectedItemId={selectedItemId}
+                                    expandedItemIds={expandedItemIds}
+                                    handleSelectChange={handleSelectChange}
+                                    defaultNodeIcon={defaultNodeIcon}
+                                    defaultLeafIcon={defaultLeafIcon}
+                                    handleDragStart={handleDragStart}
+                                    handleDrop={handleDrop}
+                                    draggedItem={draggedItem}
+                                />
+                            ) : (
+                                <TreeLeaf
+                                    item={item}
+                                    selectedItemId={selectedItemId}
+                                    handleSelectChange={handleSelectChange}
+                                    defaultLeafIcon={defaultLeafIcon}
+                                    handleDragStart={handleDragStart}
+                                    handleDrop={handleDrop}
+                                    draggedItem={draggedItem}
+                                />
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        )
+    }
+)
+TreeItem.displayName = 'TreeItem'
+
+const TreeNode = ({
+    item,
+    handleSelectChange,
+    expandedItemIds,
+    selectedItemId,
+    defaultNodeIcon,
+    defaultLeafIcon,
+    handleDragStart,
+    handleDrop,
+    draggedItem,
+}: {
+    item: TreeDataItem
+    handleSelectChange: (item: TreeDataItem | undefined) => void
+    expandedItemIds: string[]
+    selectedItemId?: string
+    defaultNodeIcon?: any
+    defaultLeafIcon?: any
+    handleDragStart?: (item: TreeDataItem) => void
+    handleDrop?: (item: TreeDataItem) => void
+    draggedItem: TreeDataItem | null
+}) => {
+    const [value, setValue] = React.useState(
+        expandedItemIds.includes(item.id) ? [item.id] : []
+    )
+    const [isDragOver, setIsDragOver] = React.useState(false)
+
+    const onDragStart = (e: React.DragEvent) => {
+        if (!item.draggable) {
+            e.preventDefault()
+            return
+        }
+        e.dataTransfer.setData('text/plain', item.id)
+        handleDragStart?.(item)
+    }
+
+    const onDragOver = (e: React.DragEvent) => {
+        if (item.droppable !== false && draggedItem && draggedItem.id !== item.id) {
+            e.preventDefault()
+            setIsDragOver(true)
+        }
+    }
+
+    const onDragLeave = () => {
+        setIsDragOver(false)
+    }
+
+    const onDrop = (e: React.DragEvent) => {
+        e.preventDefault()
+        setIsDragOver(false)
+        handleDrop?.(item)
+    }
+
+    return (
+        <AccordionPrimitive.Root
+            type="multiple"
+            value={value}
+            onValueChange={(s) => setValue(s)}
+        >
+            <AccordionPrimitive.Item value={item.id}>
+                <AccordionTrigger
+                    className={cn(
+                        treeVariants(),
+                        selectedItemId === item.id && selectedTreeVariants(),
+                        isDragOver && dragOverVariants()
+                    )}
+                    onClick={() => {
+                        handleSelectChange(item)
+                        item.onClick?.()
+                    }}
+                    draggable={!!item.draggable}
+                    onDragStart={onDragStart}
+                    onDragOver={onDragOver}
+                    onDragLeave={onDragLeave}
+                    onDrop={onDrop}
+                >
+                    <TreeIcon
+                        item={item}
+                        isSelected={selectedItemId === item.id}
+                        isOpen={value.includes(item.id)}
+                        default={defaultNodeIcon}
+                    />
+                    <span className="text-sm truncate">{item.name}</span>
+                    <TreeActions isSelected={selectedItemId === item.id}>
+                        {item.actions}
+                    </TreeActions>
+                </AccordionTrigger>
+                <AccordionContent className="ml-4 pl-1 border-l">
+                    <TreeItem
+                        data={item.children ? item.children : item}
+                        selectedItemId={selectedItemId}
+                        handleSelectChange={handleSelectChange}
+                        expandedItemIds={expandedItemIds}
+                        defaultLeafIcon={defaultLeafIcon}
+                        defaultNodeIcon={defaultNodeIcon}
+                        handleDragStart={handleDragStart}
+                        handleDrop={handleDrop}
+                        draggedItem={draggedItem}
+                    />
+                </AccordionContent>
+            </AccordionPrimitive.Item>
+        </AccordionPrimitive.Root>
+    )
+}
+
+const TreeLeaf = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement> & {
+        item: TreeDataItem
+        selectedItemId?: string
+        handleSelectChange: (item: TreeDataItem | undefined) => void
+        defaultLeafIcon?: any
+        handleDragStart?: (item: TreeDataItem) => void
+        handleDrop?: (item: TreeDataItem) => void
+        draggedItem: TreeDataItem | null
+    }
+>(
+    (
+        {
+            className,
+            item,
+            selectedItemId,
+            handleSelectChange,
+            defaultLeafIcon,
+            handleDragStart,
+            handleDrop,
+            draggedItem,
+            ...props
+        },
+        ref
+    ) => {
+        const [isDragOver, setIsDragOver] = React.useState(false)
+
+        const onDragStart = (e: React.DragEvent) => {
+            if (!item.draggable || item.disabled) {
+                e.preventDefault()
+                return
+            }
+            e.dataTransfer.setData('text/plain', item.id)
+            handleDragStart?.(item)
+        }
+
+        const onDragOver = (e: React.DragEvent) => {
+            if (item.droppable !== false && !item.disabled && draggedItem && draggedItem.id !== item.id) {
+                e.preventDefault()
+                setIsDragOver(true)
+            }
+        }
+
+        const onDragLeave = () => {
+            setIsDragOver(false)
+        }
+
+        const onDrop = (e: React.DragEvent) => {
+            if (item.disabled) return
+            e.preventDefault()
+            setIsDragOver(false)
+            handleDrop?.(item)
+        }
+
+        return (
+            <div
+                ref={ref}
+                className={cn(
+                    'ml-5 flex text-left items-center py-2 cursor-pointer before:right-1',
+                    treeVariants(),
+                    className,
+                    selectedItemId === item.id && selectedTreeVariants(),
+                    isDragOver && dragOverVariants(),
+                    item.disabled && 'opacity-50 cursor-not-allowed pointer-events-none'
+                )}
+                onClick={() => {
+                    if (item.disabled) return
+                    handleSelectChange(item)
+                    item.onClick?.()
+                }}
+                draggable={!!item.draggable && !item.disabled}
+                onDragStart={onDragStart}
+                onDragOver={onDragOver}
+                onDragLeave={onDragLeave}
+                onDrop={onDrop}
+                {...props}
+            >
+                <TreeIcon
+                    item={item}
+                    isSelected={selectedItemId === item.id}
+                    default={defaultLeafIcon}
+                />
+                <span className="flex-grow text-sm truncate">{item.name}</span>
+                <TreeActions isSelected={selectedItemId === item.id && !item.disabled}>
+                    {item.actions}
+                </TreeActions>
+            </div>
+        )
+    }
+)
+TreeLeaf.displayName = 'TreeLeaf'
+
+const AccordionTrigger = React.forwardRef<
+    React.ElementRef<typeof AccordionPrimitive.Trigger>,
+    React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+    <AccordionPrimitive.Header>
+        <AccordionPrimitive.Trigger
+            ref={ref}
+            className={cn(
+                'flex flex-1 w-full items-center py-2 transition-all first:[&[data-state=open]>svg]:rotate-90',
+                className
+            )}
+            {...props}
+        >
+            <ChevronRight className="h-4 w-4 shrink-0 transition-transform duration-200 text-accent-foreground/50 mr-1" />
+            {children}
+        </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+    React.ElementRef<typeof AccordionPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+    <AccordionPrimitive.Content
+        ref={ref}
+        className={cn(
+            'overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down',
+            className
+        )}
+        {...props}
+    >
+        <div className="pb-1 pt-0">{children}</div>
+    </AccordionPrimitive.Content>
+))
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+const TreeIcon = ({
+    item,
+    isOpen,
+    isSelected,
+    default: defaultIcon
+}: {
+    item: TreeDataItem
+    isOpen?: boolean
+    isSelected?: boolean
+    default?: any
+}) => {
+    let Icon = defaultIcon
+    if (isSelected && item.selectedIcon) {
+        Icon = item.selectedIcon
+    } else if (isOpen && item.openIcon) {
+        Icon = item.openIcon
+    } else if (item.icon) {
+        Icon = item.icon
+    }
+    return Icon ? (
+        <Icon className="h-4 w-4 shrink-0 mr-2" />
+    ) : (
+        <></>
+    )
+}
+
+const TreeActions = ({
+    children,
+    isSelected
+}: {
+    children: React.ReactNode
+    isSelected: boolean
+}) => {
+    return (
+        <div
+            className={cn(
+                isSelected ? 'block' : 'hidden',
+                'absolute right-3 group-hover:block'
+            )}
+        >
+            {children}
+        </div>
+    )
+}
+
+export { TreeView, type TreeDataItem }

--- a/client/src/components/ui/tree-view.tsx
+++ b/client/src/components/ui/tree-view.tsx
@@ -21,6 +21,7 @@ const dragOverVariants = cva(
 interface TreeDataItem {
     id: string
     name: string
+    className?: string
     icon?: any
     selectedIcon?: any
     openIcon?: any
@@ -289,7 +290,7 @@ const TreeNode = ({
                         isOpen={value.includes(item.id)}
                         default={defaultNodeIcon}
                     />
-                    <span className="text-sm truncate">{item.name}</span>
+                    <span className={cn('text-sm truncate', item.className)}>{item.name}</span>
                     <TreeActions isSelected={selectedItemId === item.id}>
                         {item.actions}
                     </TreeActions>
@@ -395,7 +396,7 @@ const TreeLeaf = React.forwardRef<
                     isSelected={selectedItemId === item.id}
                     default={defaultLeafIcon}
                 />
-                <span className="flex-grow text-sm truncate">{item.name}</span>
+                <span className={cn('flex-grow text-sm truncate', item.className)}>{item.name}</span>
                 <TreeActions isSelected={selectedItemId === item.id && !item.disabled}>
                     {item.actions}
                 </TreeActions>

--- a/client/src/components/ui/tree-view.tsx
+++ b/client/src/components/ui/tree-view.tsx
@@ -7,7 +7,7 @@ import { cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const treeVariants = cva(
-    'group hover:before:opacity-100 before:absolute before:rounded-lg before:left-0 px-2 before:w-full before:opacity-0 before:bg-accent/70 before:h-[2rem] before:-z-10'
+    'group relative w-full px-2 hover:before:opacity-100 before:absolute before:inset-y-0 before:left-0 before:right-0 before:rounded-lg before:opacity-0 before:bg-accent/70 before:-z-10'
 )
 
 const selectedTreeVariants = cva(

--- a/client/src/components/ui/tree-view.tsx
+++ b/client/src/components/ui/tree-view.tsx
@@ -476,7 +476,7 @@ const TreeActions = ({
     isSelected?: boolean
 }) => {
     return (
-        <div className="absolute right-3">
+        <div className="absolute right-3 hidden group-hover:block">
             {children}
         </div>
     )

--- a/client/src/components/ui/tree-view.tsx
+++ b/client/src/components/ui/tree-view.tsx
@@ -470,19 +470,13 @@ const TreeIcon = ({
 }
 
 const TreeActions = ({
-    children,
-    isSelected
+    children
 }: {
     children: React.ReactNode
-    isSelected: boolean
+    isSelected?: boolean
 }) => {
     return (
-        <div
-            className={cn(
-                isSelected ? 'block' : 'hidden',
-                'absolute right-3 group-hover:block'
-            )}
-        >
+        <div className="absolute right-3">
             {children}
         </div>
     )

--- a/client/src/components/ui/tree-view.tsx
+++ b/client/src/components/ui/tree-view.tsx
@@ -7,15 +7,15 @@ import { cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const treeVariants = cva(
-    'group relative w-full px-2 hover:before:opacity-100 before:absolute before:inset-y-0 before:left-0 before:right-0 before:rounded-lg before:opacity-0 before:bg-accent/70 before:-z-10'
+    'group relative w-full px-2 hover:bg-accent hover:bg-opacity-90 rounded-lg transition-colors'
 )
 
 const selectedTreeVariants = cva(
-    'before:opacity-100 before:bg-accent/70 text-accent-foreground'
+    'bg-accent bg-opacity-50 text-accent-foreground'
 )
 
 const dragOverVariants = cva(
-    'before:opacity-100 before:bg-primary/20 text-primary-foreground'
+    'bg-primary bg-opacity-20 text-primary-foreground'
 )
 
 interface TreeDataItem {
@@ -268,33 +268,35 @@ const TreeNode = ({
             onValueChange={(s) => setValue(s)}
         >
             <AccordionPrimitive.Item value={item.id}>
-                <AccordionTrigger
-                    className={cn(
-                        treeVariants(),
-                        selectedItemId === item.id && selectedTreeVariants(),
-                        isDragOver && dragOverVariants()
-                    )}
-                    onClick={() => {
-                        handleSelectChange(item)
-                        item.onClick?.()
-                    }}
-                    draggable={!!item.draggable}
-                    onDragStart={onDragStart}
-                    onDragOver={onDragOver}
-                    onDragLeave={onDragLeave}
-                    onDrop={onDrop}
-                >
-                    <TreeIcon
-                        item={item}
-                        isSelected={selectedItemId === item.id}
-                        isOpen={value.includes(item.id)}
-                        default={defaultNodeIcon}
-                    />
-                    <span className={cn('text-sm truncate', item.className)}>{item.name}</span>
+                <div className={cn("relative group", treeVariants())}>
+                    <AccordionTrigger
+                        className={cn(
+                            'group relative w-full px-2 rounded-lg transition-colors',
+                            selectedItemId === item.id && selectedTreeVariants(),
+                            isDragOver && dragOverVariants()
+                        )}
+                        onClick={() => {
+                            handleSelectChange(item)
+                            item.onClick?.()
+                        }}
+                        draggable={!!item.draggable}
+                        onDragStart={onDragStart}
+                        onDragOver={onDragOver}
+                        onDragLeave={onDragLeave}
+                        onDrop={onDrop}
+                    >
+                        <TreeIcon
+                            item={item}
+                            isSelected={selectedItemId === item.id}
+                            isOpen={value.includes(item.id)}
+                            default={defaultNodeIcon}
+                        />
+                        <span className={cn('text-sm truncate', item.className)}>{item.name}</span>
+                    </AccordionTrigger>
                     <TreeActions isSelected={selectedItemId === item.id}>
                         {item.actions}
                     </TreeActions>
-                </AccordionTrigger>
+                </div>
                 <AccordionContent className="ml-4 pl-1 border-l">
                     <TreeItem
                         data={item.children ? item.children : item}
@@ -476,7 +478,7 @@ const TreeActions = ({
     isSelected?: boolean
 }) => {
     return (
-        <div className="absolute right-3 hidden group-hover:block">
+        <div className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity">
             {children}
         </div>
     )

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -39,12 +39,15 @@ export default function CTCHierarchyPage() {
   const treeData: TreeDataItem[] = hierarchy.map((cls) => ({
     id: String(cls.id),
     name: cls.name,
+    className: "text-indigo-700",
     children: cls.types.map((type) => ({
       id: `t-${type.id}`,
       name: type.name,
+      className: "text-emerald-700",
       children: type.categories.map((cat) => ({
         id: `c-${cat.id}`,
         name: cat.name,
+        className: "text-gray-700",
       })),
     })),
   }));

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -82,8 +82,9 @@ export default function CTCHierarchyPage() {
     className: "text-gray-800",
     actions: (
       <Button
-        variant="ghost"
-        size="xs"
+        variant="secondary"
+        size="sm"
+        className="text-gray-800"
         onClick={(e) => {
           e.stopPropagation();
           setFbTarget({ level: "class", id: cls.id, name: cls.name });
@@ -98,8 +99,9 @@ export default function CTCHierarchyPage() {
       className: "text-gray-600",
       actions: (
         <Button
-          variant="ghost"
-          size="xs"
+        variant="secondary"
+        size="sm"
+        className="text-gray-800"
           onClick={(e) => {
             e.stopPropagation();
             setFbTarget({ level: "type", id: type.id, name: type.name });
@@ -114,8 +116,9 @@ export default function CTCHierarchyPage() {
         className: "text-gray-500",
         actions: (
           <Button
-            variant="ghost"
-            size="xs"
+            variant="secondary"
+            size="sm"
+            className="text-gray-800"
             onClick={(e) => {
               e.stopPropagation();
               setFbTarget({ level: "category", id: cat.id, name: cat.name });

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -6,6 +6,8 @@ import { ListTree, Bell } from "lucide-react";
 import { TreeView, TreeDataItem } from "@/components/ui/tree-view";
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import CTCFeaturesDialog from "@/components/ctc-features-dialog";
 
 interface CTCCategoryHierarchy {
   id: number;
@@ -39,6 +41,10 @@ export default function CTCHierarchyPage() {
     queryKey: ["/ctc/hierarchy"],
   });
   const [query, setQuery] = React.useState("");
+  const [fbTarget, setFbTarget] = React.useState<
+    | { level: "class" | "type" | "category"; id: number; name: string }
+    | null
+  >(null);
 
   const filteredHierarchy = React.useMemo(() => {
     if (!query.trim()) return hierarchy;
@@ -74,14 +80,50 @@ export default function CTCHierarchyPage() {
     id: String(cls.id),
     name: cls.name,
     className: "text-gray-800",
+    actions: (
+      <Button
+        variant="ghost"
+        size="xs"
+        onClick={(e) => {
+          e.stopPropagation();
+          setFbTarget({ level: "class", id: cls.id, name: cls.name });
+        }}
+      >
+        Features
+      </Button>
+    ),
     children: cls.types.map((type) => ({
       id: `t-${type.id}`,
       name: type.name,
       className: "text-gray-600",
+      actions: (
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={(e) => {
+            e.stopPropagation();
+            setFbTarget({ level: "type", id: type.id, name: type.name });
+          }}
+        >
+          Features
+        </Button>
+      ),
       children: type.categories.map((cat) => ({
         id: `c-${cat.id}`,
         name: cat.name,
         className: "text-gray-500",
+        actions: (
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={(e) => {
+              e.stopPropagation();
+              setFbTarget({ level: "category", id: cat.id, name: cat.name });
+            }}
+          >
+            Features
+          </Button>
+        ),
       })),
     })),
   }));
@@ -119,6 +161,15 @@ export default function CTCHierarchyPage() {
                 <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />
               </div>
               <TreeView data={treeData} expandAll className="bg-white rounded p-4" />
+              {fbTarget && (
+                <CTCFeaturesDialog
+                  open={!!fbTarget}
+                  onOpenChange={(o) => !o && setFbTarget(null)}
+                  level={fbTarget.level}
+                  sourceId={fbTarget.id}
+                  name={fbTarget.name}
+                />
+              )}
             </>
           )}
         </main>

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -39,15 +39,15 @@ export default function CTCHierarchyPage() {
   const treeData: TreeDataItem[] = hierarchy.map((cls) => ({
     id: String(cls.id),
     name: cls.name,
-    className: "text-indigo-700",
+    className: "text-gray-800",
     children: cls.types.map((type) => ({
       id: `t-${type.id}`,
       name: type.name,
-      className: "text-emerald-700",
+      className: "text-gray-600",
       children: type.categories.map((cat) => ({
         id: `c-${cat.id}`,
         name: cat.name,
-        className: "text-gray-700",
+        className: "text-gray-500",
       })),
     })),
   }));

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import CTCFeaturesDialog from "@/components/ctc-features-dialog";
+import CTCAttributesDialog from "@/components/ctc-attributes-dialog";
 
 interface CTCCategoryHierarchy {
   id: number;
@@ -43,6 +44,10 @@ export default function CTCHierarchyPage() {
   const [query, setQuery] = React.useState("");
   const [fbTarget, setFbTarget] = React.useState<
     | { level: "class" | "type" | "category"; id: number; name: string }
+    | null
+  >(null);
+  const [attrTarget, setAttrTarget] = React.useState<
+    | { id: number; name: string }
     | null
   >(null);
 
@@ -115,17 +120,30 @@ export default function CTCHierarchyPage() {
         name: cat.name,
         className: "text-gray-500",
         actions: (
-          <Button
-            variant="secondary"
-            size="sm"
-            className="text-gray-800"
-            onClick={(e) => {
-              e.stopPropagation();
-              setFbTarget({ level: "category", id: cat.id, name: cat.name });
-            }}
-          >
-            Features
-          </Button>
+          <div className="space-x-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              className="text-gray-800"
+              onClick={(e) => {
+                e.stopPropagation();
+                setFbTarget({ level: "category", id: cat.id, name: cat.name });
+              }}
+            >
+              Features
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="text-gray-800"
+              onClick={(e) => {
+                e.stopPropagation();
+                setAttrTarget({ id: cat.id, name: cat.name });
+              }}
+            >
+              Attributes
+            </Button>
+          </div>
         ),
       })),
     })),
@@ -171,6 +189,14 @@ export default function CTCHierarchyPage() {
                   level={fbTarget.level}
                   sourceId={fbTarget.id}
                   name={fbTarget.name}
+                />
+              )}
+              {attrTarget && (
+                <CTCAttributesDialog
+                  open={!!attrTarget}
+                  onOpenChange={(o) => !o && setAttrTarget(null)}
+                  categoryId={attrTarget.id}
+                  name={attrTarget.name}
                 />
               )}
             </>

--- a/client/src/pages/ctc-hierarchy.tsx
+++ b/client/src/pages/ctc-hierarchy.tsx
@@ -1,0 +1,80 @@
+import { useQuery } from "@tanstack/react-query";
+import Sidebar from "@/components/sidebar";
+import UserMenu from "@/components/user-menu";
+import { ListTree, Bell } from "lucide-react";
+import { TreeView, TreeDataItem } from "@/components/ui/tree-view";
+
+interface CTCCategoryHierarchy {
+  id: number;
+  uuid: string;
+  code: string;
+  name: string;
+  active: boolean;
+  product_id?: number | null;
+}
+
+interface CTCTypeHierarchy {
+  id: number;
+  uuid: string;
+  code: string;
+  name: string;
+  active: boolean;
+  categories: CTCCategoryHierarchy[];
+}
+
+interface CTCClassHierarchy {
+  id: number;
+  uuid: string;
+  code: string;
+  name: string;
+  active: boolean;
+  types: CTCTypeHierarchy[];
+}
+
+export default function CTCHierarchyPage() {
+  const { data: hierarchy = [], isLoading } = useQuery<CTCClassHierarchy[]>({
+    queryKey: ["/ctc/hierarchy"],
+  });
+
+  const treeData: TreeDataItem[] = hierarchy.map((cls) => ({
+    id: String(cls.id),
+    name: cls.name,
+    children: cls.types.map((type) => ({
+      id: `t-${type.id}`,
+      name: type.name,
+      children: type.categories.map((cat) => ({
+        id: `c-${cat.id}`,
+        name: cat.name,
+      })),
+    })),
+  }));
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm border-b border-gray-200 sticky top-0 z-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <ListTree className="text-primary text-2xl mr-3" />
+              <h1 className="text-xl font-semibold text-gray-900">CTC Hierarchy</h1>
+            </div>
+            <div className="flex items-center space-x-4">
+              <Bell className="h-5 w-5 text-gray-400" />
+              <UserMenu />
+            </div>
+          </div>
+        </div>
+      </header>
+      <div className="flex h-screen pt-16">
+        <Sidebar />
+        <main className="flex-1 overflow-auto p-6">
+          {isLoading ? (
+            <div>Loading...</div>
+          ) : (
+            <TreeView data={treeData} expandAll className="bg-white rounded p-4" />
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add tree-view component from shadcn-tree-view
- implement CTC hierarchy page showing the class/type/category hierarchy
- expose the page in the router and sidebar

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68771a2f12b4832884ab855a9fbd9370